### PR TITLE
Add SandiaPC Pressure Fitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Option Categories
     - **--fit_type <fit> <fit> ... (Default: poly5)**
 
     Select an equation to fit to the data points for each region. For example, if you have three regions, --fit_type none poly5 birch3 would set no equation for the first region, poly5 for the second region, and birch3 for the third region. Regions are ordered from smallest to greatest x value. If a fit_type is not specified for any region, then the default poly5 equation will be used. This means if there are five regions, but only three fit types, the the last two regions will be set to poly5. The available equations are:
-    anton, ap1, ap2, bardeen, birch2, birch3, birch4, ebirch3, ebirch4, emurnaghan, evinet, johnson, kumari, log, log2, murnaghan, none, poly1, poly2, poly3, poly4, poly5, poly6, poly7, poly8, poly9, poly10, poly11, poly12, shank, vinet, highp.
+    anton, ap1, ap2, bardeen, birch2, birch3, birch4, ebirch3, ebirch4, emurnaghan, evinet, johnson, kumari, log, log2, murnaghan, none, poly1, poly2, poly3, poly4, poly5, poly6, poly7, poly8, poly9, poly10, poly11, poly12, sandiapc, shank, vinet, highp.
     Options starting with an 'e' are energy equations, poly<n> are nth degree polynomials, and the rest are pressure. Only some of these equations have been thoroughly tested to check if they work properly. These are:
     birch2, birch3, birch4, ebirch3, ebirch4, emurnaghan, evinet, murnaghan, none, all polys, vinet.
     When inputting this argument in a configuration file, make sure to enclose all options in brackets.
@@ -228,7 +228,7 @@ Option Categories
 
     - **--rho0_guess <positive float>**
 
-    Set an initial guess for equilibrium density (rho0).
+    Set an initial guess for equilibrium density (rho0) or fixed guess if using the fitter 'sandiapc'.
 
     - **--scale_derivative_by <float> (Default: 1000)**
 

--- a/curvallis/curve_editing/curve_fitters.py
+++ b/curvallis/curve_editing/curve_fitters.py
@@ -28,9 +28,8 @@ import scipy.optimize as opt
 import scipy.special as spec
 import scipy.interpolate as interp
 from pylab import polyfit
-from math import e, factorial
-import bisect
 import math
+import bisect
 
 def define_args(parser):
     fitter_args = parser.add_argument_group(
@@ -776,6 +775,23 @@ class Murnaghan(Pressure_Fit_Class):
 
 factory.register ('murnaghan', Murnaghan)
 
+
+
+class SandiaPC(Pressure_Fit_Class):
+    def __init__(self, args, name):
+        super(SandiaPC, self).__init__(args, name)
+        self.rho0 = args.rho0
+
+    def _set_coefficients(self, coeffs):
+        (self.rho0) = coeffs
+
+    def _get_coefficients(self):
+        return self.rho0
+
+    def _print_coefficients(self):
+        print ("rho0 = {};".format(self.rho0))
+
+factory.register ('sandiapc', SandiaPC)
 
 #------------------------------------------------------------------------------
 # Working EOS models:

--- a/curvallis/curve_editing/curve_fitters.py
+++ b/curvallis/curve_editing/curve_fitters.py
@@ -388,11 +388,11 @@ class Pressure_Fit_Class(Base_Fit_Class):
             (not hasattr (self, 'rho0'))):
 
             # If not, set defaults for required coefficients
-            if (hasattr (self, 'k0')):
+            if (not hasattr (self, 'k0')):
                 self.k0 = 1.0e11
-            if (hasattr (self, 'k0_prime')):
+            if (not hasattr (self, 'k0_prime')):
                 self.k0_prime = 20.0
-            if (hasattr (self, 'rho0')):
+            if (not hasattr (self, 'rho0')):
                 self.rho0 = 5.0
 
             return

--- a/curvallis/curve_editing/curve_fitters.py
+++ b/curvallis/curve_editing/curve_fitters.py
@@ -134,6 +134,7 @@ def define_args(parser):
         k0_prime_prime=1.0,
         e0 = None,              #Energy Curve, calcualted in guess_coefficients
         kneg1=1.0,
+	kneg0=1.0,
         k1=1.0,
         k2=1.0,
         k3=1.0,
@@ -787,7 +788,7 @@ class SandiaPC(Pressure_Fit_Class):
     def __init__(self, args, name):
         super(SandiaPC, self).__init__(args, name)
         self.kneg1 = args.kneg1
-	self.k0    = args.k0
+	self.kneg0 = args.kneg0
 	self.k1    = args.k1
 	self.k2    = args.k2
 	self.k3    = args.k3
@@ -796,14 +797,14 @@ class SandiaPC(Pressure_Fit_Class):
         self.rho0  = args.rho0
 
     def _set_coefficients(self, coeffs):
-        (self.kneg1, self.k0, self.k1, self.k2, self.k3, self.k4, self.k5, self.rho0) = coeffs
+        (self.kneg1, self.kneg0, self.k1, self.k2, self.k3, self.k4, self.k5, self.rho0) = coeffs
 
     def _get_coefficients(self):
-        return self.kneg1, self.k0, self.k1, self.k2, self.k3, self.k4, self.k5, self.rho0
+        return self.kneg1, self.kneg0, self.k1, self.k2, self.k3, self.k4, self.k5, self.rho0
 
     def _print_coefficients(self):
         print ("kneg1 = {};".format(self.kneg1))
-        print ("k0 = {};".format(self.k0))
+        print ("k0 = {};".format(self.kneg0))
         print ("k1 = {};".format(self.k1))
         print ("k2 = {};".format(self.k2))
         print ("k3 = {};".format(self.k3))
@@ -813,10 +814,10 @@ class SandiaPC(Pressure_Fit_Class):
 
     @staticmethod
     def _f(x, *coeffs):
-        (kneg1, k0, k1, k2, k3, k4, k5, rho0) = coeffs
+        (kneg1, kneg0, k1, k2, k3, k4, k5, rho0) = coeffs
         y = _eta(x, rho0)
         return kneg1 * y**(-1) + \
-               k0 * 1 + \
+               kneg0 * 1 + \
                k1 * y + \
                k2 * y**2 + \
                k3 * y**3 + \

--- a/curvallis/curve_editing/curve_fitters.py
+++ b/curvallis/curve_editing/curve_fitters.py
@@ -388,11 +388,11 @@ class Pressure_Fit_Class(Base_Fit_Class):
             (not hasattr (self, 'rho0'))):
 
             # If not, set defaults for required coefficients
-            if (not hasattr (self, 'k0')):
+            if (hasattr (self, 'k0')):
                 self.k0 = 1.0e11
-            if (not hasattr (self, 'k0_prime')):
+            if (hasattr (self, 'k0_prime')):
                 self.k0_prime = 20.0
-            if (not hasattr (self, 'rho0')):
+            if (hasattr (self, 'rho0')):
                 self.rho0 = 5.0
 
             return

--- a/curvallis/curve_editing/io.py
+++ b/curvallis/curve_editing/io.py
@@ -269,11 +269,21 @@ def process_args (parser, args):
             parser.error('Both --in_eos_file_base and --out_eos_file_base '
                          'must be set, or neither must be set.')
 
+    def check_sandiapc_rho0():
+        """ If the fitter sandiapc is selected, the user must
+            be forced to enter the constant "rho0" instead of
+            Curvallis gussing it.
+        """
+	if args.rho0 is None and "sandiapc" in args.fit_type:
+            parser.error('If using the fitter "sandiapc" you must '
+                         'give a value for "rho0_guess".')
+
     check_no_config_file()
     check_decimate_and_step()
     check_input_arg()
     check_output_arg()
     check_eos_args()
+    check_sandiapc_rho0()
 
 class XY_Limits(object):
     """ Contains an x range and a y range.

--- a/examples/1dsandiapc1.ini
+++ b/examples/1dsandiapc1.ini
@@ -1,0 +1,103 @@
+[general]
+# background_file: background.dat
+# curve_output_file_name: filename.dat
+# use_eos_info_file: True
+# eos_function: Ec
+
+[inputs]
+#in_eos_file_base: 2dexample1.dat
+
+# Read in a 1d data file. This is two column data plotted as a
+# single line. By default a 5th degree polynomial will be fitted
+# to this data and displayed as a red line. This command is the 
+# simplest possible config file.
+input_file: 1dexample1.dat
+
+
+# parabola_in
+# predefined_in
+
+[outputs]
+# out_eos_file_base: 2dDataOut.dat
+# output_file_name: 1dDataOut.dat
+
+[regions]
+# do_derivative
+# do_integral
+# points_in_fit_curve: 200
+# points_in_user_curve: 50
+# region_bound [10, 20, 100]
+# overlap 5
+
+[Shifts, Limits, and Point Exclusion]
+# decimate: 20
+# step: 3
+# x_include: [1, 30]
+# x_scale: [2, 0, 100]
+# x_shift: [50, 0, 100]
+# y_include: [0, 300]
+# y_scale: [2, 0, 100]
+# y_shift: [50, 0, 100]
+# t_include: [0, 20000]
+# v_axis
+
+[view]
+#x_max: 100
+#x_min: 10
+#y_max: 200
+#y_min: 0
+
+[fitter]
+fit_type: sandiapc
+# refine_fit: [none, none, poly5]
+# scale_derivative_by: 100
+# scale_integral_by: .001
+# xref: 6.7
+# y_axis: E
+# yref: 5.4
+
+rho0_guess: 5.0
+# delta_p_guess: 3.6
+# k0_guess: 3.6
+# k0_prime_guess: 4.0
+# k0_prime_prime_guess: 1.1
+# lam_guess: 3.4
+# e0_guess: 30.6
+
+[automatic smoothing]
+# numpoints: 4
+# repeat: 5
+# matchpt: 1.0
+# interp: cubic
+# angle 50
+
+###############################################################################
+
+# This is a configuration file for curve_editor.py.  This file is parsed with 
+# configargparse.  Some format details:
+
+# in any column starts a comment 
+; in any column also starts a comment (.ini style)
+--- in the FIRST column starts a comment (.yaml style)
+
+# These all set 'name' to value. 'name' is the command-line option, without the
+# leading '--'.  The key is case sensitive: "Name" is not "name":
+# name value
+# name = value   # (.ini style)  (white space is ignored, so name = value same as name=value)
+# name: value    # (yaml style)
+# --name value   # (argparse style)
+
+# These all set name to True. '=', ':', and '--' work similarly:
+# --name
+# name    
+# name True
+# name true
+
+# To specify an argument with multiple values:
+# NOT!
+# To specify an argument with a type of 'list':
+# fruit = [apple, orange, lemon]
+# indexes = [1, 12, 35 , 40]
+
+[section]      # .ini-style section names are treated as comments
+

--- a/examples/1dsandiapc2.ini
+++ b/examples/1dsandiapc2.ini
@@ -1,0 +1,103 @@
+[general]
+# background_file: background.dat
+# curve_output_file_name: filename.dat
+# use_eos_info_file: True
+# eos_function: Ec
+
+[inputs]
+#in_eos_file_base: 2dexample1.dat
+
+# Read in a 1d data file. This is two column data plotted as a
+# single line. By default a 5th degree polynomial will be fitted
+# to this data and displayed as a red line. This command is the 
+# simplest possible config file.
+input_file: 1dexample2.dat
+
+
+# parabola_in
+# predefined_in
+
+[outputs]
+# out_eos_file_base: 2dDataOut.dat
+# output_file_name: 1dDataOut.dat
+
+[regions]
+# do_derivative
+# do_integral
+# points_in_fit_curve: 200
+# points_in_user_curve: 50
+# region_bound [10, 20, 100]
+# overlap 5
+
+[Shifts, Limits, and Point Exclusion]
+# decimate: 20
+# step: 3
+# x_include: [1, 30]
+# x_scale: [2, 0, 100]
+# x_shift: [50, 0, 100]
+# y_include: [0, 300]
+# y_scale: [2, 0, 100]
+# y_shift: [50, 0, 100]
+# t_include: [0, 20000]
+# v_axis
+
+[view]
+#x_max: 100
+#x_min: 10
+#y_max: 200
+#y_min: 0
+
+[fitter]
+fit_type: sandiapc
+# refine_fit: [none, none, poly5]
+# scale_derivative_by: 100
+# scale_integral_by: .001
+# xref: 6.7
+# y_axis: E
+# yref: 5.4
+
+rho0_guess: 5.0
+# delta_p_guess: 3.6
+# k0_guess: 3.6
+# k0_prime_guess: 4.0
+# k0_prime_prime_guess: 1.1
+# lam_guess: 3.4
+# e0_guess: 30.6
+
+[automatic smoothing]
+# numpoints: 4
+# repeat: 5
+# matchpt: 1.0
+# interp: cubic
+# angle 50
+
+###############################################################################
+
+# This is a configuration file for curve_editor.py.  This file is parsed with 
+# configargparse.  Some format details:
+
+# in any column starts a comment 
+; in any column also starts a comment (.ini style)
+--- in the FIRST column starts a comment (.yaml style)
+
+# These all set 'name' to value. 'name' is the command-line option, without the
+# leading '--'.  The key is case sensitive: "Name" is not "name":
+# name value
+# name = value   # (.ini style)  (white space is ignored, so name = value same as name=value)
+# name: value    # (yaml style)
+# --name value   # (argparse style)
+
+# These all set name to True. '=', ':', and '--' work similarly:
+# --name
+# name    
+# name True
+# name true
+
+# To specify an argument with multiple values:
+# NOT!
+# To specify an argument with a type of 'list':
+# fruit = [apple, orange, lemon]
+# indexes = [1, 12, 35 , 40]
+
+[section]      # .ini-style section names are treated as comments
+


### PR DESCRIPTION
Applies the SandiaPC pressure fitter and makes the 'rho0_guess' input mandatory when using said fitter (as requested by Christine). Addresses Issue #7.