### PR TITLE
Background Marker Size Changing

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,14 @@ Interactive commands can be inputted while the plotter is running. When using th
 
     Undo the last data manipulation. This include moving an moving points, rotating points, adding points, and removing points. This does not undo screen changes, like zooming or panning. This will only undo the last change, no more previous changes are stored.
 
+    - **h**
+
+    Increase the size of the background markers. These background markers are placed when a file is given as an input to the "background_file" optional arguement.
+
+    - **j**
+
+    Decrease the size of the background markers. These background markers are placed when a file is given as an input to the "background_file" optional arguement.
+
     - **<shift> Q**
 
     Pop a window to enter an equation to plot. Equations must be entered using Python syntax. For example, x^2 doesn't work, you have to use either x**2 or pow(x,2). Check the Python Math library to see a list of available math related functions to use. To plot the entered equation, press the plot button. To remove the plotted equation, press the delete button. If the user wants to plot multiple equations, pressing <shift> Q will continue to open new windows to plot more equations. After closing a window, the equation plotted from that window is deleted. After plotting an equation, the user can write the points to a file by specifying a file name in the "Filename" Entry and clicking "Write". The equation must be plotted and a file name must be specified before any points will be written.

--- a/curvallis/curve_editing/lines.py
+++ b/curvallis/curve_editing/lines.py
@@ -85,6 +85,9 @@ class Line(object):
     def get_point_count(self):
         return len(self.get_xy_data())
 
+    def get_marker_size(self):
+        return self._id.get_markersize()
+
     def point_to_data_space(self, x, y):
         """ Convert a point in display coordinates, as in an callback event, to
         a point in data coordinates.
@@ -163,7 +166,9 @@ class Line(object):
             self._highlight.set_data(zip(*xy_data))
         else:
             self._highlight.set_data([],[])            
-        
+
+    def set_marker_size(self, pts):
+        self._id.set_markersize(pts)
 
     def set_x_data_y_data(self, x_data_y_data):
         """

--- a/curvallis/run.py
+++ b/curvallis/run.py
@@ -771,6 +771,8 @@ class CurveInteractor(object):
         print('Press a to toggle adding and removing points with left and right click \n[default: off]')
         print('Press e to toggle selecting a block of points')
         print('Press u to undo the last point manipulation')
+        print('Press h to increase size of background markers')
+        print('Press j to decrease size of background markers')
         print('Press <shift> Q to enter an equation to plot')
         print('Press <shift> Z for trilocal smoothing')
         print('Press <shift> X for integral smoothing')

--- a/curvallis/run.py
+++ b/curvallis/run.py
@@ -470,13 +470,13 @@ class CurveInteractor(object):
                 self._canvas.draw()
             elif event.key == 'h':
                 #Increase background point marker size
-                lines.line_attributes['background_points']['markersize'] *= 1.25
-                self._plot_background_data()
+                for i in range(len(self._background_line)):
+                    self._background_line[i].set_marker_size(self._background_line[i].get_marker_size() * 1.25)
                 self._canvas.draw()
             elif event.key == 'j':
                 #Decrease background point marker size
-                lines.line_attributes['background_points']['markersize'] *= 0.75
-                self._plot_background_data()
+                for i in range(len(self._background_line)):
+                    self._background_line[i].set_marker_size(self._background_line[i].get_marker_size() * 0.8)
                 self._canvas.draw()
 
     def xlim_changed_callback(self, event):

--- a/curvallis/run.py
+++ b/curvallis/run.py
@@ -468,6 +468,16 @@ class CurveInteractor(object):
                     self._ax.set_yscale('linear')
                 self._set_xlim_ylim()
                 self._canvas.draw()
+            elif event.key == 'h':
+                #Increase background point marker size
+                lines.line_attributes['background_points']['markersize'] *= 1.25
+                self._plot_background_data()
+                self._canvas.draw()
+            elif event.key == 'j':
+                #Decrease background point marker size
+                lines.line_attributes['background_points']['markersize'] *= 0.75
+                self._plot_background_data()
+                self._canvas.draw()
 
     def xlim_changed_callback(self, event):
         """ xlim is changed by a zoom or a pan


### PR DESCRIPTION
Feature requested by Christine. One can now press the "h" and "j" keys while focused on the plot to increase and decrease the size of the background file markers, if present on the graph, respectively. Any thoughts @leek2?